### PR TITLE
Filter out empty folder names

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ export function faviconURL(u: string, imgSize: string) {
 }
 
 export function determineFolderNames(foldersAsString: string) {
-  return foldersAsString.split(',').map((folderName) => folderName.trim());
+  return foldersAsString.split(',').map((folderName) => folderName.trim()).filter(Boolean);
 }
 
 export function truncateLongText(text: string) {


### PR DESCRIPTION
## Summary
- Fix `determineFolderNames('')` returning `['']` instead of `[]`
- Add `.filter(Boolean)` after split/trim to discard empty strings
- Prevents a wasted bookmark lookup for a folder named `""`

## Test plan
- [ ] Verify `determineFolderNames('')` returns `[]`
- [ ] Verify `determineFolderNames('Foo, Bar')` still returns `['Foo', 'Bar']`