### PR TITLE
Always clear firstRun flag when saving settings

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -89,10 +89,9 @@ export class Settings {
   }
 
   async save(newSettings?: Partial<SettingsProps>) {
-    if (newSettings) {
-      await chrome.storage.local.set({[Settings.SETTINGS_ROOT_KEY]: {...this.settings, ...newSettings, ...{firstRun: false}}});
-    } else {
-      await chrome.storage.local.set({[Settings.SETTINGS_ROOT_KEY]: {...this.settings}});
-    }
+    const settingsToSave = newSettings
+        ? {...this.settings, ...newSettings, firstRun: false}
+        : {...this.settings, firstRun: false};
+    await chrome.storage.local.set({[Settings.SETTINGS_ROOT_KEY]: settingsToSave});
   }
 }

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -93,5 +93,6 @@ export class Settings {
         ? {...this.settings, ...newSettings, firstRun: false}
         : {...this.settings, firstRun: false};
     await chrome.storage.local.set({[Settings.SETTINGS_ROOT_KEY]: settingsToSave});
+    this.settings = settingsToSave;
   }
 }


### PR DESCRIPTION
## Summary

- Fix consistency issue in `Settings.save()` where `firstRun` was only set to `false` when `newSettings` was provided (settings dialog save), but not when called without arguments (the `saveOne()` path).
- This caused `saveOne()` to persist settings changes while keeping `firstRun: true`, which made the "no bookmarks" message persist after initial configuration.

## Test plan

- [ ] Verify that after `saveOne()` is called, `firstRun` is `false` in stored settings.
- [ ] Verify that saving from the settings dialog still sets `firstRun` to `false`.