### PR TITLE
Guard drag-end to prevent unwanted bookmark reorder

### DIFF
--- a/src/View.ts
+++ b/src/View.ts
@@ -54,10 +54,12 @@ export class View {
       $bookmark.addEventListener("dragend", (e) => {
         const selectedItem = e.target as HTMLElement;
         selectedItem.classList.remove('drag-sort-active');
-        // Re-order in Chrome.
-        this.bookmarks.move(selectedItem.dataset.id || '', selectedItem.dataset.indexSwap || '', selectedItem.dataset.parentIdSwap || '');
-        delete selectedItem.dataset.indexSwap;
-        delete selectedItem.dataset.parentIdSwap;
+        // Only move if a swap actually occurred
+        if (selectedItem.dataset.indexSwap) {
+          this.bookmarks.move(selectedItem.dataset.id || '', selectedItem.dataset.indexSwap, selectedItem.dataset.parentIdSwap || '');
+          delete selectedItem.dataset.indexSwap;
+          delete selectedItem.dataset.parentIdSwap;
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- Added a guard in the `dragend` event handler in `src/View.ts` so that `bookmarks.move()` is only called when a swap actually occurred (i.e., `dataset.indexSwap` is set).
- Previously, dragging a bookmark and dropping it in the same position would call `move(id, '', '')`, silently corrupting bookmark order.

## Test plan
- [ ] Drag a bookmark and drop it in the same position — verify no `bookmarks.move()` call is made.
- [ ] Drag a bookmark to a new position — verify the bookmark is reordered correctly.