### PR TITLE
Throttle drag handler with requestAnimationFrame

### DIFF
--- a/src/View.ts
+++ b/src/View.ts
@@ -27,34 +27,43 @@ export class View {
     // Handle drag
     if (isDraggable) {
       $bookmark.setAttribute("draggable", "true");
+      let animationFrame = 0;
       $bookmark.addEventListener("drag", (e: DragEvent) => {
-        const selectedItem = e.target as HTMLElement;
-        if (!selectedItem) {
-          return;
-        }
+        if (animationFrame) return;
+        animationFrame = requestAnimationFrame(() => {
+          animationFrame = 0;
+          const selectedItem = e.target as HTMLElement;
+          if (!selectedItem) {
+            return;
+          }
 
-        const x = e.clientX, y = e.clientY;
+          const x = e.clientX, y = e.clientY;
 
-        selectedItem.classList.add('drag-sort-active');
-        const rawElement = document.elementFromPoint(x, y);
-        if (!rawElement) return;
-        let swapItem = rawElement.closest('.bookmark') as HTMLElement;
-        if (!swapItem) return;
-        const list = selectedItem.parentNode;
+          selectedItem.classList.add('drag-sort-active');
+          const rawElement = document.elementFromPoint(x, y);
+          if (!rawElement) return;
+          let swapItem = rawElement.closest('.bookmark') as HTMLElement;
+          if (!swapItem) return;
+          const list = selectedItem.parentNode;
 
-        if (!list) {
-          return;
-        }
+          if (!list) {
+            return;
+          }
 
-        if (swapItem !== selectedItem && list === swapItem.parentNode) {
-          swapItem = swapItem !== selectedItem.nextSibling as HTMLElement ? swapItem : swapItem.nextSibling as HTMLElement;
-          list.insertBefore(selectedItem, swapItem);
-          selectedItem.dataset.indexSwap = swapItem.dataset.index;
-          selectedItem.dataset.parentIdSwap = swapItem.dataset.parentId;
-          // console.log(selectedItem.innerText, swapItem.innerText);
-        }
+          if (swapItem !== selectedItem && list === swapItem.parentNode) {
+            swapItem = swapItem !== selectedItem.nextSibling as HTMLElement ? swapItem : swapItem.nextSibling as HTMLElement;
+            list.insertBefore(selectedItem, swapItem);
+            selectedItem.dataset.indexSwap = swapItem.dataset.index;
+            selectedItem.dataset.parentIdSwap = swapItem.dataset.parentId;
+            // console.log(selectedItem.innerText, swapItem.innerText);
+          }
+        });
       });
       $bookmark.addEventListener("dragend", async (e) => {
+        if (animationFrame) {
+          cancelAnimationFrame(animationFrame);
+          animationFrame = 0;
+        }
         const selectedItem = e.target as HTMLElement;
         selectedItem.classList.remove('drag-sort-active');
         if (selectedItem.dataset.indexSwap) {


### PR DESCRIPTION
## Summary

- Wraps the `drag` event handler in `requestAnimationFrame` to throttle DOM-heavy operations (elementFromPoint, insertBefore) to once per frame
- Adds `cancelAnimationFrame` cleanup in the `dragend` handler to prevent stale callbacks after drop

This reduces layout thrashing and visible jank when dragging bookmarks, especially with large bookmark collections.