### PR TITLE
Single-pass tree traversal for multi-folder lookup

### DIFF
--- a/src/Bookmarks.ts
+++ b/src/Bookmarks.ts
@@ -42,15 +42,21 @@ export class Bookmarks {
     }
 
     const rootFolders = determineFolderNames(this.settings.getValue("rootFolderName") || '');
-    const folderMap = Bookmarks.getBookmarksFromFolders(new Set(rootFolders), rootBookmarkTreeNode);
+    const validFolders = rootFolders.filter(name => name.length > 0);
+    if (validFolders.length === 0) {
+      return null;
+    }
+    const folderMap = Bookmarks.getBookmarksFromFolders(new Set(validFolders), rootBookmarkTreeNode);
 
-    return rootFolders.map(folderName => ({
+    return validFolders.map(folderName => ({
       folderName,
       node: folderMap.get(folderName) || null
     }));
   }
 
   static getBookmarksFromFolders(folderNames: Set<string>, treeItem: BookmarkTreeNode): Map<string, BookmarkTreeNode> {
+    if (folderNames.size === 0) return new Map();
+
     const results = new Map<string, BookmarkTreeNode>();
 
     function traverse(node: BookmarkTreeNode) {

--- a/src/Bookmarks.ts
+++ b/src/Bookmarks.ts
@@ -42,13 +42,32 @@ export class Bookmarks {
     }
 
     const rootFolders = determineFolderNames(this.settings.getValue("rootFolderName") || '');
+    const folderMap = Bookmarks.getBookmarksFromFolders(new Set(rootFolders), rootBookmarkTreeNode);
 
-    return rootFolders.map(folderName => {
-      return {
-        folderName,
-        node: Bookmarks.getBookmarksFromFolder(folderName, rootBookmarkTreeNode)
+    return rootFolders.map(folderName => ({
+      folderName,
+      node: folderMap.get(folderName) || null
+    }));
+  }
+
+  static getBookmarksFromFolders(folderNames: Set<string>, treeItem: BookmarkTreeNode): Map<string, BookmarkTreeNode> {
+    const results = new Map<string, BookmarkTreeNode>();
+
+    function traverse(node: BookmarkTreeNode) {
+      if (folderNames.has(node.title) && !results.has(node.title)) {
+        results.set(node.title, node);
+        if (results.size === folderNames.size) return;
       }
-    });
+      if (node.children) {
+        for (const child of node.children) {
+          traverse(child);
+          if (results.size === folderNames.size) return;
+        }
+      }
+    }
+
+    traverse(treeItem);
+    return results;
   }
 
   static getBookmarksFromFolder(folderName: string, treeItem: BookmarkTreeNode): BookmarkTreeNode | null {


### PR DESCRIPTION
## Summary
- Added `getBookmarksFromFolders` static method that traverses the bookmark tree once to collect all matching folders, with early exit when all are found.
- Updated `getSelectedBookmarksByFolder` to use the new single-pass method instead of calling `getBookmarksFromFolder` per folder (N traversals reduced to 1).
- Kept the existing `getBookmarksFromFolder` method intact for single-folder lookups.