### PR TITLE
Use replaceChildren() to clear search results

### DIFF
--- a/src/View.ts
+++ b/src/View.ts
@@ -105,7 +105,7 @@ export class View {
       const query = (e.target as HTMLInputElement).value.trim();
       const bookmarksFound = this.bookmarks.search(query);
 
-      $results.innerHTML = '';
+      $results.replaceChildren();
       $bookmarks.classList.remove("blur");
 
       if (bookmarksFound && bookmarksFound.length > 0) {


### PR DESCRIPTION
## Summary

- Replace `$results.innerHTML = ''` with `$results.replaceChildren()` in `renderSearchBookmarks()` to clear search results more efficiently on each keystroke.
- `replaceChildren()` is a cleaner DOM API for removing all child nodes without going through the HTML parser.