### PR TITLE
Debounce search input handler

### DIFF
--- a/src/View.ts
+++ b/src/View.ts
@@ -117,23 +117,32 @@ export class View {
       (e.target as HTMLInputElement).setAttribute("placeholder", "Search my bookmarks ...");
     });
 
+    let debounceTimer = 0;
     $searchField.addEventListener("input", (e: Event) => {
-      const query = (e.target as HTMLInputElement).value.trim();
-      const bookmarksFound = this.bookmarks.search(query);
+      clearTimeout(debounceTimer);
 
       $results.replaceChildren();
+      $results.style.display = 'none';
       $bookmarks.classList.remove("blur");
 
-      if (bookmarksFound && bookmarksFound.length > 0) {
-        bookmarksFound.forEach((bookmark) => {
-          const size = this.settings.getValue("bookmarkItemSize") === "large" ? 32 : 16;
-          const $bookmark = this.renderBookmark(bookmark, size, false);
-          $results.appendChild($bookmark);
-        });
+      debounceTimer = window.setTimeout(() => {
+        const query = (e.target as HTMLInputElement).value.trim();
+        if (!query) {
+          return;
+        }
+        const bookmarksFound = this.bookmarks.search(query);
 
-        $results.style.display = 'block';
-        $bookmarks.classList.add("blur");
-      }
+        if (bookmarksFound && bookmarksFound.length > 0) {
+          bookmarksFound.forEach((bookmark) => {
+            const size = this.settings.getValue("bookmarkItemSize") === "large" ? 32 : 16;
+            const $bookmark = this.renderBookmark(bookmark, size, false);
+            $results.appendChild($bookmark);
+          });
+
+          $results.style.display = 'block';
+          $bookmarks.classList.add("blur");
+        }
+      }, 200);
     });
   }
 


### PR DESCRIPTION
## Summary
- Add a 200ms debounce to the search input handler in `renderSearchBookmarks()` to avoid triggering a full bookmark tree traversal and DOM rebuild on every keystroke.

## Test plan
- [ ] Type quickly in the search field and verify the search only executes after a 200ms pause in typing.
- [ ] Verify search results still appear correctly after debounce fires.
- [ ] Verify the blur class is applied/removed as expected.