### PR TITLE
Exclude folders from bookmark search results

### DIFF
--- a/src/Bookmarks.ts
+++ b/src/Bookmarks.ts
@@ -89,7 +89,7 @@ export class Bookmarks {
       return results;
     }
 
-    if (treeItem.url && treeItem.title.toLowerCase().search(query.toLowerCase()) !== -1) {
+    if (treeItem.url && treeItem.title.toLowerCase().includes(query.toLowerCase())) {
       results.push(treeItem);
     }
 

--- a/src/Bookmarks.ts
+++ b/src/Bookmarks.ts
@@ -89,7 +89,7 @@ export class Bookmarks {
       return results;
     }
 
-    if (treeItem.title.toLowerCase().search(query.toLowerCase()) !== -1) {
+    if (treeItem.url && treeItem.title.toLowerCase().search(query.toLowerCase()) !== -1) {
       results.push(treeItem);
     }
 


### PR DESCRIPTION
## Summary

- Fixed a bug in `searchRecursive` where folder nodes matching the search query were included in results
- Added a `treeItem.url` check so only actual bookmarks (not folders) appear in search results
- Prevents `window.location.href` from being set to an empty string when clicking a folder result

## Test plan

- [ ] Search for a term that matches both a folder name and bookmark titles
- [ ] Verify only bookmarks (with URLs) appear in search results
- [ ] Verify clicking any search result navigates to a valid URL