### PR TITLE
Fix drag-and-drop targeting child elements

### DIFF
--- a/src/View.ts
+++ b/src/View.ts
@@ -36,10 +36,13 @@ export class View {
         const x = e.clientX, y = e.clientY;
 
         selectedItem.classList.add('drag-sort-active');
-        let swapItem = (document.elementFromPoint(x, y) === null ? selectedItem : document.elementFromPoint(x, y)) as HTMLElement;
+        const rawElement = document.elementFromPoint(x, y);
+        if (!rawElement) return;
+        let swapItem = rawElement.closest('.bookmark') as HTMLElement;
+        if (!swapItem) return;
         const list = selectedItem.parentNode;
 
-        if (!swapItem || !list) {
+        if (!list) {
           return;
         }
 


### PR DESCRIPTION
## Summary

- Fix bug where `document.elementFromPoint()` in the drag handler could return child elements (`<img>`, `<span>`) inside a `.bookmark` div instead of the bookmark div itself
- When a child element was returned, `swapItem.dataset.index` was `undefined`, causing `Number('')` to silently move the bookmark to position 0 on `dragend`
- Use `.closest('.bookmark')` to walk up the DOM and find the actual bookmark container, and bail out early if no bookmark is found at the pointer location

## Test plan

- [ ] Drag a bookmark by clicking on its icon (`<img>`) and verify it swaps correctly with neighbors
- [ ] Drag a bookmark by clicking on its title (`<span>`) and verify it swaps correctly
- [ ] Drag a bookmark by clicking on the `.bookmark` div background and verify it still works
- [ ] Verify dragging over empty space (no `.bookmark` ancestor) does not cause errors or unexpected moves